### PR TITLE
Added proper spacing for contributor cards

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -92,8 +92,8 @@
 /* 3. Contributors Grid */
 .contributors-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); /* Slightly narrower columns */
-    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); /* Slightly narrower columns */
+    gap: 42px;
     min-height: 200px;
 }
 
@@ -104,7 +104,7 @@
     text-align: center;
     border: 1px solid var(--border-color);
     transition: all 0.3s ease;
-    
+    min-height: 150px;
     /* Layout Fixes for Height */
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
I have added a proper spacing for contributor cards . Check it once


<img width="1776" height="732" alt="image" src="https://github.com/user-attachments/assets/29295ce3-a248-4728-bbcc-3368a2a6c46f" />
