### PR TITLE
Lift-up Hover Effect for Seminar Cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,7 +248,7 @@ body {
     transform: scale(1.2) rotate(10deg);
 }
 
-<
+
 /* HAMBURGER BUTTON */
 .hamburger {
     display: none; /* shown only on small screens */
@@ -341,7 +341,7 @@ body {
 }
 
 /* THEME TOGGLE */
-=======
+
 /* THEME TOGGLE - ENHANCED */
 
 .theme-toggle {


### PR DESCRIPTION
Added a smooth lift-up hover effect to all seminar cards in the LIVE_TRANSMISSIONS section. The cards now slightly lift and scale when hovered, with a subtle shadow and border color highlight to make them more interactive and visually appealing. Images inside the cards also slightly scale on hover for an enhanced effect.
<img width="1366" height="728" alt="Pixel Phantoms _ The Future of Tech - Google Chrome 30-11-2025 14_15_45" src="https://github.com/user-attachments/assets/c88136ae-de8d-4dfa-b0d2-10e27270be73" />
