### PR TITLE
Fix: Footer in white mode color not showing properly

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,25 +15,25 @@
   --nav-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
   
   /* Footer Light Theme Variables */
-  --footer-bg: #1a1a2e;
-  --footer-bg-secondary: #16213e;
-  --footer-text: #e6e6e6;
-  --footer-text-secondary: #a0aec0;
-  --footer-heading: #ffffff;
-  --footer-link: #cbd5e0;
-  --footer-link-hover: #ffffff;
-  --footer-border: #2d3748;
-  --social-bg: #2d3748;
-  --social-bg-hover: #4a5568;
-  --social-icon: #cbd5e0;
-  --social-icon-hover: #ffffff;
-  --social-border: #4a5568;
-  --input-bg: #2d3748;
-  --input-border: #4a5568;
-  --input-text: #e2e8f0;
-  --input-placeholder: #718096;
-  --accent-primary: #667eea;
-  --accent-secondary: #764ba2;
+  --footer-bg: #f8f9fa;
+  --footer-bg-secondary: #ffffff;
+  --footer-text: #333333;
+  --footer-text-secondary: #666666;
+  --footer-heading: #000000;
+  --footer-link: #00aaff;
+  --footer-link-hover: #0088cc;
+  --footer-border: rgba(0, 0, 0, 0.1);
+  --social-bg: #e9ecef;
+  --social-bg-hover: #dee2e6;
+  --social-icon: #495057;
+  --social-icon-hover: #000000;
+  --social-border: rgba(0, 0, 0, 0.1);
+  --input-bg: #ffffff;
+  --input-border: rgba(0, 0, 0, 0.1);
+  --input-text: #333333;
+  --input-placeholder: #6c757d;
+  --accent-primary: #00aaff;
+  --accent-secondary: #0088cc;
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
#94 

### Problem
In the light/white theme mode, the footer does not display with proper light colors. The footer background and text colors remained dark, making it look inconsistent with the rest of the light theme. This was caused by the CSS variables for the footer in light mode being incorrectly set to dark colors instead of appropriate light colors.

### Solution
Updated the CSS variables for the footer in light mode (`:root`) to use appropriate light colors:
- Changed footer background colors from dark blues to light grays/whites
- Updated text colors from light to dark for proper contrast
- Adjusted social media icon colors for better visibility in light mode
- Modified border colors to use rgba values for better transparency effects

### How it fixes the issue
By correcting the CSS variables in the `:root` selector for light mode, the footer now properly responds to theme changes and displays with appropriate light colors when the light theme is active, maintaining consistency across the entire website.
Let 