### PR TITLE
Fix: Hardcoded Image Paths in Leaderboard Component Cause Broken Images

### DIFF
--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -315,7 +315,7 @@ function renderLeaderboardTable(data) {
         row.innerHTML = `
             <td class="rank-cell">#${String(agent.rank).padStart(2,'0')}</td>
             <td class="agent-cell">
-                <img src="${agent.avatar}" onerror="this.src='../assets/logo.png'">
+                <img src="${agent.avatar}" onerror="this.src='assets/logo.png'">
                 <div>
                     <span class="agent-name">${agent.login}</span>
                     <span class="agent-sub">Events: ${agent.events} | PRs: ${agent.prCount}</span>
@@ -403,7 +403,7 @@ function populateRoster(data) {
         const item = document.createElement('li');
         item.className = 'roster-item';
         item.innerHTML = `
-            <img src="${agent.avatar}" onerror="this.src='../assets/logo.png'">
+            <img src="${agent.avatar}" onerror="this.src='assets/logo.png'">
             <div>
                 <strong style="color:#e0f7ff; display:block; font-size:0.9rem;">${agent.login}</strong>
                 <span style="font-size:0.7rem; color:#5c7080;">${agent.xp} XP</span>


### PR DESCRIPTION
By removing the hardcoded ../ prefix, the image paths now resolve correctly relative to the current page location, ensuring that the fallback logo image loads properly when avatar images fail to load. This improves the user experience by preventing broken image icons in the leaderboard.