### PR TITLE
Add “Click Logo to Return to Landing Page” Feature #110

### DIFF
--- a/js/navbar.js
+++ b/js/navbar.js
@@ -2,19 +2,23 @@ function renderNavbar(basePath = '') {
     const navbarHTML = `
     <nav class="navbar">
         <div class="logo">
-            <img src="${basePath}assets/logo.png" alt="Pixel Phantoms Logo">
-            <span>Pixel Phantoms</span>
+            <a href="${basePath}index.html" class="logo-link">
+                <img src="${basePath}assets/logo.png" alt="Pixel Phantoms Logo">
+                <span>Pixel Phantoms</span>
+            </a>
         </div>
+
         <button class="hamburger" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-links">
             <span class="bar"></span>
             <span class="bar"></span>
             <span class="bar"></span>
         </button>
+
         <ul class="nav-links">
             <li><a href="${basePath}index.html">Home</a></li>
             <li><a href="${basePath}about.html">About</a></li>
-             <li><a href="${basePath}events.html">Events</a></li>
-            <li><a href="${basePath}pages/contributors.html">Team</a></li> 
+            <li><a href="${basePath}events.html">Events</a></li>
+            <li><a href="${basePath}pages/contributors.html">Team</a></li>
             <li><a href="${basePath}contact.html">Contact</a></li>
             <li>
                 <div class="theme-toggle">
@@ -29,17 +33,18 @@ function renderNavbar(basePath = '') {
         </ul>
     </nav>
     `;
-    // Render HTML
+
+    
     document.getElementById('navbar-placeholder').innerHTML = navbarHTML;
 
 
-    // Add toggle behavior for hamburger (scoped to this navbar instance)
+   
     const container = document.getElementById('navbar-placeholder');
     const hamburger = container.querySelector('.hamburger');
     const navLinks = container.querySelector('.nav-links');
 
     if (hamburger && navLinks) {
-        // toggle on click
+        
         hamburger.addEventListener('click', function () {
             const expanded = this.getAttribute('aria-expanded') === 'true';
             this.setAttribute('aria-expanded', String(!expanded));
@@ -47,7 +52,7 @@ function renderNavbar(basePath = '') {
             this.classList.toggle('open');
         });
 
-        // close when a link is clicked (mobile behavior)
+        
         container.querySelectorAll('.nav-links a').forEach(function (a) {
             a.addEventListener('click', function () {
                 navLinks.classList.remove('open');
@@ -56,7 +61,7 @@ function renderNavbar(basePath = '') {
             });
         });
 
-        // close on escape key
+      
         document.addEventListener('keydown', function (e) {
             if (e.key === 'Escape') {
                 navLinks.classList.remove('open');


### PR DESCRIPTION
 Issue #110  Resolved

In this PR, I solved a navigation and user-experience problem where users had no quick way to return to the top of the landing page.

**Before this PR:**

- If a user scrolled to the bottom of the landing page → they had to manually scroll up.

- If they visited any other route → they had to use the browser back button.
 
- The logo had no interaction, so it wasn’t helping in navigation.
 
- This created friction and felt unintuitive, especially for long pages.
 

**What I Implemented **

- I implemented a feature where clicking the website’s logo automatically takes the user back to the top of the landing page.

- If the user is already on the landing page, it scrolls to the top smoothly.

- If they are on any other route, clicking the logo redirects them back to the landing page.”
 
**Screenshots/Demo -**


https://github.com/user-attachments/assets/6bc5dd44-7216-491a-894a-80f3757f3a1d


 **How I Tested It** 

I tested this feature thoroughly in multiple scenarios:

**Scenario 1:** User is already on landing page

- Scrolled to different sections

- Clicked the logo
 
- Confirmed smooth and instant scroll back to the top
 
- No layout shifts, no jitter
 

 **Scenario 2:** User is on another route

- Navigated to different pages
 
- Clicked the logo from each page
 
- Verified correct redirect to landing page
 
- Confirmed the page loads at the top position

**Scenario 4:** Rapid clicking

- Clicked the logo repeatedly

- Ensured no unexpected behavior or double navigation

 **Why This Feature Is Beneficial for the Project**

**1. Industry-standard UX**

- Most modern websites use the logo as a “go to home” action.

- Adding this makes the product feel more polished and intuitive.

**2. Better navigation**

- Users can now reach the landing page instantly without scrolling or using the back button.

**3. Helps on long pages**

- For long landing pages, manually scrolling up is frustrating.

- This PR removes that friction completely.

**4. Improves accessibility**

- Users with mobility issues or small screens benefit from single-click navigation.

**5. Increases professionalism**

- This small UX detail makes the website feel more complete and user-friendly.