### PR TITLE
Fixed !! - Fix Leaderboard Navigation Links and Theme Toggle Functionality

### DIFF
--- a/css/leaderboard.css
+++ b/css/leaderboard.css
@@ -3,6 +3,7 @@
    ========================================= */
 
 :root {
+    /* Default Dark Theme Variables */
     --hud-bg: #050505;
     --panel-bg: rgba(16, 20, 24, 0.8);
     --panel-border: 1px solid rgba(0, 255, 255, 0.15);
@@ -17,8 +18,24 @@
     --font-mono: 'JetBrains Mono', monospace;
 }
 
+/* Light Theme Overrides */
+[data-theme="light"] {
+    --hud-bg: #f0f2f5;
+    --panel-bg: rgba(255, 255, 255, 0.9);
+    --panel-border: 1px solid rgba(0, 0, 0, 0.1);
+    --neon-cyan: #0077b6; /* Darker blue for visibility on light bg */
+    --neon-purple: #7209b7;
+    --neon-green: #008000;
+    --neon-red: #d00000;
+    --neon-yellow: #e6b800;
+    --text-main: #1a1a1a;
+    --text-dim: #555555;
+}
+
 body.hud-mode {
     background-color: var(--hud-bg);
+    /* Adjust gradient opacity for light mode via variables if needed, 
+       or simply use the background color */
     background-image: 
         radial-gradient(circle at 15% 50%, rgba(0, 243, 255, 0.05), transparent 25%),
         radial-gradient(circle at 85% 30%, rgba(188, 19, 254, 0.05), transparent 25%);
@@ -26,6 +43,7 @@ body.hud-mode {
     overflow-x: hidden;
     color: var(--text-main);
     margin: 0;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .dashboard-container {
@@ -37,7 +55,7 @@ body.hud-mode {
 /* --- SIDEBAR --- */
 .hud-sidebar {
     width: 80px;
-    background: rgba(10, 10, 15, 0.8);
+    background: var(--panel-bg); /* Updated to use var for theme switching */
     border-right: 1px solid rgba(255,255,255,0.05);
     display: flex;
     flex-direction: column;
@@ -45,6 +63,7 @@ body.hud-mode {
     padding-top: 30px;
     z-index: 10;
     backdrop-filter: blur(10px);
+    transition: background 0.3s ease;
 }
 
 .sidebar-icon {

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,9 +1,11 @@
+// js/footer.js
+
 function renderFooter(basePath = '') {
     const footerHTML = `
     <div class="footer-container">
         <div class="footer-content">
             <div class="footer-brand">
-                <div class="footer-logo">
+                 <div class="footer-logo">
                     <img src="${basePath}assets/logo.png" alt="Pixel Phantoms Logo">
                     <span class="brand-name">Pixel Phantoms</span>
                 </div>
@@ -11,27 +13,10 @@ function renderFooter(basePath = '') {
                     A community of passionate developers, designers, and creators building amazing digital experiences.
                 </p>
                 <div class="social-links">
-                    <a href="https://github.com/sayeeg-11/Pixel_Phantoms" 
-                    target="_blank" 
-                    class="social-link" 
-                    aria-label="GitHub">
-                    <i class="fab fa-github"></i></a>
-                    <a href="https://www.linkedin.com/company/pixel-phantoms/"
-                    target="_blank"
-                    class="social-link"
-                    aria-label="LinkedIn">
-                    <i class="fab fa-linkedin"></i></a>
-                    <a href="https://x.com/phantoms_pixel" 
-                    target="_blank" 
-                    class="social-link" 
-                    aria-label="Twitter">\
-                    <i class="fab fa-twitter"></i></a>
-                    <a href="https://discord.com/channels/1049667734025289729/1440205974806986844"
-                    target="_blank"
-                    class="social-link" 
-                    aria-label="Discord">
-                    <i class="fab fa-discord"></i></a>
-                    
+                    <a href="https://github.com/sayeeg-11/Pixel_Phantoms" target="_blank" class="social-link" aria-label="GitHub"><i class="fab fa-github"></i></a>
+                    <a href="https://www.linkedin.com/company/pixel-phantoms/" target="_blank" class="social-link" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                    <a href="https://x.com/phantoms_pixel" target="_blank" class="social-link" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+                    <a href="https://discord.com/channels/1049667734025289729/1440205974806986844" target="_blank" class="social-link" aria-label="Discord"><i class="fab fa-discord"></i></a>
                 </div>
             </div>
 
@@ -49,7 +34,7 @@ function renderFooter(basePath = '') {
                 <div class="link-group">
                     <h3 class="link-group-title">Community</h3>
                     <ul class="link-list">
-                        <li><a href="${basePath}pages/community.html">Community</a></li>
+                        <li><a href="${basePath}pages/leaderboard.html">Leaderboard</a></li> <li><a href="${basePath}pages/community.html">Community</a></li>
                         <li><a href="${basePath}pages/projects.html">Projects</a></li>
                         <li><a href="${basePath}pages/gallery.html">Gallery</a></li>
                         <li><a href="${basePath}pages/join-us.html">Join Us</a></li>
@@ -66,7 +51,7 @@ function renderFooter(basePath = '') {
                     </ul>
                 </div>
             </div>
-
+            
             <div class="footer-newsletter">
                 <h3 class="newsletter-title">Stay Updated</h3>
                 <p class="newsletter-description">Subscribe to our newsletter for the latest updates.</p>


### PR DESCRIPTION
### Summary
This PR addresses missing navigation links to the Leaderboard page in both the header and footer and fixes the theme toggle functionality on `pages/leaderboard.html` to correctly apply light mode styles.

# Fixes #133 

### Changes Proposed
* **Navigation (`js/navbar.js`):** Added a "Leaderboard" link to the main navigation menu to ensure users can access the page from the global header.
* **Footer (`js/footer.js`):** Added a "Leaderboard" link under the "Community" section of the footer for better site accessibility.
* **Styling (`css/leaderboard.css`):** Introduced `[data-theme="light"]` CSS variable overrides to the root definitions. This ensures that when the theme switcher toggles the `data-theme` attribute, the visual styles correctly update from the default dark mode to light mode.

### Reasoning
* **Navigation:** Users previously had no direct way to navigate to the Leaderboard page from the Home page or other sections.
* **Theme:** While `js/theme.js` was correctly toggling the `data-theme` attribute, `css/leaderboard.css` lacked the corresponding light theme variable definitions, causing the page to visually remain in dark mode regardless of the toggle state.

### Testing
* Verified that clicking "Leaderboard" in the Navbar redirects to `pages/leaderboard.html`.
* Verified that clicking "Leaderboard" in the Footer redirects to `pages/leaderboard.html`.
* Verified that clicking the Sun/Moon icon on the Leaderboard page instantly switches the color scheme (backgrounds, text, borders) between light and dark modes.
* Confirmed that the selected theme persists across page reloads via `localStorage`.

# Footer Now !!

<img width="1905" height="537" alt="Screenshot 2025-12-05 214008" src="https://github.com/user-attachments/assets/2cde750a-8eb2-4195-ace2-3d91907626ed" />

# Lightmode

<img width="1897" height="910" alt="Screenshot 2025-12-05 213611" src="https://github.com/user-attachments/assets/bc7d0631-e626-48ee-8b93-313ae898ab1c" />
<img width="1900" height="935" alt="Screenshot 2025-12-05 213556" src="https://github.com/user-attachments/assets/b44d2ca0-73c2-4d7f-83a7-4eae2e43e8f5" />
<img width="1899" height="936" alt="Screenshot 2025-12-05 213538" src="https://github.com/user-attachments/assets/cf52f6f2-ac18-4d9a-8f44-fea5af8f7dfe" />
<img width="1902" height="937" alt="Screenshot 2025-12-05 213525" src="https://github.com/user-attachments/assets/e04e9c9d-09ee-456b-9e94-9f6fb17365f8" />
<img width="1905" height="936" alt="Screenshot 2025-12-05 213515" src="https://github.com/user-attachments/assets/d941ffd1-e8c6-4cfb-a5f9-5abd588cfa58" />
