### PR TITLE
Improve light‑mode contrast and CTA styling on Phantom Node tutorial page

### DIFF
--- a/pages/tutorials/phantom-node.html
+++ b/pages/tutorials/phantom-node.html
@@ -1,145 +1,201 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tutorial: Phantom Node | Pixel Phantoms</title>
 
-    <link rel="stylesheet" href="../../css/scroll-progress.css" />
-    <link rel="stylesheet" href="../../css/style.css" />
-    <link rel="stylesheet" href="../../css/back-to-top.css" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;800&display=swap"
-      rel="stylesheet"
-    />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tutorial: Phantom Node | Pixel Phantoms</title>
 
-    <style>
-      .tutorial-content {
-        max-width: 800px;
-        margin: 100px auto;
-        padding: 20px;
-        color: #eee;
-        font-family: 'JetBrains Mono', monospace;
-      }
-      .tutorial-header {
-        border-bottom: 2px solid #ffd700;
-        margin-bottom: 40px;
-        padding-bottom: 20px;
-      }
-      .tutorial-header h1 {
-        color: #ffd700;
-        font-size: 2.5rem;
-        text-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
-      }
-      .meta-data {
-        color: #888;
-        font-size: 0.9rem;
-      }
-      h2 {
-        color: #fff;
-        margin-top: 40px;
-        border-left: 4px solid #ffd700;
-        padding-left: 15px;
-      }
-      .component-list {
-        background: #111;
-        padding: 20px;
-        border: 1px solid #333;
-        border-radius: 8px;
-        list-style: none;
-      }
-      .component-list li {
-        margin-bottom: 10px;
-        display: flex;
-        justify-content: space-between;
-      }
-      .price {
-        color: #00ff41;
-      }
-      code {
-        background: #222;
-        padding: 2px 5px;
-        border-radius: 3px;
-        color: #ff9100;
-      }
-      pre {
-        background: #111;
-        padding: 15px;
-        overflow-x: auto;
-        border: 1px solid #333;
-        color: #ccc;
-      }
-      .warning-box {
-        background: rgba(255, 0, 0, 0.1);
-        border: 1px solid red;
-        padding: 15px;
-        margin: 20px 0;
-        color: #ffaaaa;
-      }
-    </style>
-  </head>
-  <body class="hacker-theme">
-    <div id="scroll-progress-container">
-      <div id="scroll-progress-bar"></div>
+  <link rel="stylesheet" href="../../css/scroll-progress.css" />
+  <link rel="stylesheet" href="../../css/style.css" />
+  <link rel="stylesheet" href="../../css/back-to-top.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet" />
+
+  <style>
+    .tutorial-content {
+      max-width: 800px;
+      margin: 100px auto;
+      padding: 20px;
+      /* use theme token so text is readable in light & dark */
+      color: var(--text-primary);
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    .tutorial-header {
+      border-bottom: 2px solid #ffd700;
+      margin-bottom: 40px;
+      padding-bottom: 20px;
+    }
+
+    .tutorial-header h1 {
+      color: #ffd700;
+      font-size: 2.5rem;
+      text-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
+    }
+
+    .meta-data {
+      /* secondary token instead of low-contrast #888 */
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    h2 {
+
+      color: var(--text-primary);
+      margin-top: 40px;
+      border-left: 4px solid #ffd700;
+      padding-left: 15px;
+    }
+
+    .component-list {
+      background: #111;
+      padding: 20px;
+      border: 1px solid #333;
+      border-radius: 8px;
+      list-style: none;
+      color: #f5f5f5;
+    }
+
+    .component-list li {
+      margin-bottom: 10px;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .price {
+      color: #00ff41;
+    }
+
+    code {
+      background: #222;
+      padding: 2px 5px;
+      border-radius: 3px;
+      color: #ff9100;
+    }
+
+    pre {
+      background: #111;
+      padding: 15px;
+      overflow-x: auto;
+      border: 1px solid #333;
+      color: #ccc;
+    }
+
+    .warning-box {
+      /* tweak for better contrast on light bg */
+      background: rgba(255, 0, 0, 0.08);
+      border: 1px solid rgba(255, 0, 0, 0.6);
+      padding: 15px;
+      margin: 20px 0;
+      color: #b00020;
+    }
+
+    /* RETURN TO ROADMAP button */
+    .btn-cyber {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 26px;
+      border-radius: 10px;
+      text-decoration: none;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: linear-gradient(135deg, var(--accent-color) 0%, #0088cc 100%);
+      color: #ffffff;
+      border: 1px solid rgba(0, 0, 0, 0.35);
+      box-shadow: 0 0 0 1px rgba(0, 255, 255, 0.2);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    }
+
+    .btn-cyber:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 18px rgba(0, 170, 255, 0.4);
+      filter: brightness(1.05);
+    }
+
+    .btn-cyber:focus-visible {
+      outline: 2px solid #ffffff;
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(0, 170, 255, 0.7);
+    }
+  </style>
+</head>
+
+<body class="hacker-theme">
+  <div id="scroll-progress-container">
+    <div id="scroll-progress-bar"></div>
+  </div>
+
+  <div id="cursor-highlight"></div>
+  <div id="navbar-placeholder"></div>
+  <script src="../../js/navbar.js"></script>
+  <script>
+    renderNavbar('../../');
+  </script>
+
+  <div class="tutorial-content">
+    <div class="tutorial-header">
+      <h1>PROJECT: PHANTOM_NODE</h1>
+      <p class="meta-data">
+        >> DIFFICULTY: BEGINNER | EST. COST: $4.50 | TIME: 45 MINS
+      </p>
     </div>
 
-    <div id="cursor-highlight"></div>
-    <div id="navbar-placeholder"></div>
-    <script src="../../js/navbar.js"></script>
-    <script>
-      renderNavbar('../../');
-    </script>
+    <p>
+      This protocol will guide you through constructing a basic IoT sensor node
+      capable of reporting temperature data to the cloud via MQTT. This is the
+      fundamental unit of the Pixel Phantoms hardware network.
+    </p>
 
-    <div class="tutorial-content">
-      <div class="tutorial-header">
-        <h1>PROJECT: PHANTOM_NODE</h1>
-        <p class="meta-data">>> DIFFICULTY: BEGINNER | EST. COST: $4.50 | TIME: 45 MINS</p>
-      </div>
+    <h2>// 01_ACQUIRE_HARDWARE</h2>
+    <ul class="component-list">
+      <li>
+        <span>ESP8266 (NodeMCU or Wemos D1 Mini)</span>
+        <span class="price">~$3.00</span>
+      </li>
+      <li>
+        <span>DHT11 Temperature Sensor</span>
+        <span class="price">~$1.00</span>
+      </li>
+      <li>
+        <span>Jumper Wires (Female-to-Female)</span>
+        <span class="price">~$0.50</span>
+      </li>
+      <li>
+        <span>Micro-USB Cable</span>
+        <span class="price">(Existing)</span>
+      </li>
+    </ul>
 
-      <p>
-        This protocol will guide you through constructing a basic IoT sensor node capable of
-        reporting temperature data to the cloud via MQTT. This is the fundamental unit of the Pixel
-        Phantoms hardware network.
-      </p>
-
-      <h2>// 01_ACQUIRE_HARDWARE</h2>
-      <ul class="component-list">
-        <li><span>ESP8266 (NodeMCU or Wemos D1 Mini)</span> <span class="price">~$3.00</span></li>
-        <li><span>DHT11 Temperature Sensor</span> <span class="price">~$1.00</span></li>
-        <li><span>Jumper Wires (Female-to-Female)</span> <span class="price">~$0.50</span></li>
-        <li><span>Micro-USB Cable</span> <span class="price">(Existing)</span></li>
-      </ul>
-
-      <h2>// 02_WIRING_DIAGRAM</h2>
-      <p>
-        Connect the components as follows. Ensure the board is disconnected from power while wiring.
-      </p>
-      <pre>
+    <h2>// 02_WIRING_DIAGRAM</h2>
+    <p>
+      Connect the components as follows. Ensure the board is disconnected from
+      power while wiring.
+    </p>
+    <pre>
 ESP8266      DHT11
 ------------------
 3V3 (or 5V)  -> VCC (+)
 GND          -> GND (-)
 D1 (GPIO 5)  -> DATA (Signal)
-        </pre
-      >
+      </pre>
 
-      <div class="warning-box">
-        <i class="fas fa-exclamation-triangle"></i> WARNING: Double-check your VCC and GND
-        connections. Reversing polarity will fry your sensor instantly.
-      </div>
+    <div class="warning-box">
+      <i class="fas fa-exclamation-triangle"></i>
+      WARNING: Double-check your VCC and GND connections. Reversing polarity
+      will fry your sensor instantly.
+    </div>
 
-      <h2>// 03_FLASH_FIRMWARE</h2>
-      <p>
-        1. Install the <code>Arduino IDE</code>.<br />
-        2. Add ESP8266 board manager URL in Preferences.<br />
-        3. Install the <code>DHT sensor library</code> by Adafruit.
-      </p>
+    <h2>// 03_FLASH_FIRMWARE</h2>
+    <p>
+      1. Install the <code>Arduino IDE</code>.<br />
+      2. Add ESP8266 board manager URL in Preferences.<br />
+      3. Install the <code>DHT sensor library</code> by Adafruit.
+    </p>
 
-      <pre><code>
+    <pre><code>
 #include &lt;ESP8266WiFi.h&gt;
 #include &lt;DHT.h&gt;
 
@@ -162,26 +218,28 @@ void loop() {
   Serial.println(t);
   delay(2000);
 }
-        </code></pre>
+      </code></pre>
 
-      <h2>// 04_DEPLOYMENT</h2>
-      <p>
-        Upload the code and open the Serial Monitor (115200 baud). You should see temperature
-        readings streaming in. You have successfully initialized a Phantom Node.
-      </p>
+    <h2>// 04_DEPLOYMENT</h2>
+    <p>
+      Upload the code and open the Serial Monitor (115200 baud). You should see
+      temperature readings streaming in. You have successfully initialized a
+      Phantom Node.
+    </p>
 
-      <p style="margin-top: 50px; text-align: center">
-        <a href="../hardware-roadmap.html" class="btn-cyber">RETURN TO ROADMAP</a>
-      </p>
-    </div>
+    <p style="margin-top: 50px; text-align: center">
+      <a href="../hardware-roadmap.html" class="btn-cyber">RETURN TO ROADMAP</a>
+    </p>
+  </div>
 
-    <div id="footer-placeholder"></div>
-    <script src="../../js/footer.js"></script>
-    <script>
-      renderFooter('../../');
-    </script>
-    <script src="../../js/theme.js"></script>
-    <script src="../../js/back-to-top.js"></script>
-    <script src="../../js/scroll-progress.js"></script>
-  </body>
+  <div id="footer-placeholder"></div>
+  <script src="../../js/footer.js"></script>
+  <script>
+    renderFooter('../../');
+  </script>
+  <script src="../../js/theme.js"></script>
+  <script src="../../js/back-to-top.js"></script>
+  <script src="../../js/scroll-progress.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Summary
This PR updates the phantom-node.html tutorial to fix light‑mode readability issues and improve the “RETURN TO ROADMAP” call‑to‑action button styling. Text that was previously nearly invisible against the light background now uses theme tokens and accessible color combinations, and the roadmap link is styled as a clear primary button that fits the existing cyber theme.
​
Changes

- Switch tutorial body text and section headings to use var(--text-primary) and var(--text-secondary) instead of hard‑coded light colors.
- Adjust .component-list text color so hardware list items have sufficient contrast against the dark card background in light mode.
- Update .warning-box colors to maintain a warning appearance while improving contrast on light backgrounds.
- Add .btn-cyber styles so “RETURN TO ROADMAP” renders as a high‑contrast, theme‑consistent CTA with hover and focus states.

<img width="1894" height="842" alt="image" src="https://github.com/user-attachments/assets/5e786233-80e6-493e-a2bf-f232194cac85" />
<img width="1890" height="833" alt="image" src="https://github.com/user-attachments/assets/23105a93-273d-4646-8037-a19f68e6a0c5" />


Closes #415 