### PR TITLE
Add tutorials page and update footer link to tutorials.html (issue #582)

### DIFF
--- a/js/footer.js
+++ b/js/footer.js
@@ -93,7 +93,7 @@ function renderFooter(basePath = '') {
             <div class="footer-bottom-links">
               <a href="${basePath}pages/privacy.html" class="bottom-link">Privacy</a> | 
               <a href="${basePath}pages/terms.html" class="bottom-link">Terms</a> | 
-              <a href="${basePath}pages/tutorials/phantom-node.html" class="bottom-link">Tutorials</a>
+              <a href="${basePath}pages/tutorials.html" class="bottom-link">Tutorials</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The footer's "Tutorials" link now points to the main tutorials page (pages/tutorials.html) instead of the phantom-node tutorial. 

Closes #582 