### PR TITLE
Fix: Remove 'Lo' text from navbar - hide loader and skip-to-content l…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -746,7 +746,11 @@ body.mobile-menu-open {
     }
 
     .theme-label {
-      transition-property: background, border-color, box-shadow, -webkit-background;
+      transition-property:
+        background,
+        border-color,
+        box-shadow,
+        -webkit-background;
     }
   }
 }
@@ -2242,7 +2246,6 @@ body.mobile-menu-open {
   margin-right: 0;
   padding: 0 2rem;
   box-sizing: border-box;
-
 }
 
 .copyright {
@@ -3427,8 +3430,8 @@ main:focus {
 .scroll-to-top,
 #back-to-top {
   bottom: 90px !important; /* 20px base + 54px icon + 16px gap */
-    right: 28px !important;
-    position: fixed !important;
+  right: 28px !important;
+  position: fixed !important;
 }
 
 @media (max-width: 420px) {
@@ -3449,7 +3452,7 @@ main:focus {
   .scroll-to-top,
   #back-to-top {
     bottom: 12px !important;
-    right:  12px !important;
+    right: 12px !important;
   }
 
   #feedback-panel {
@@ -3915,8 +3918,8 @@ code,
 
 .leaderboard-preview .share-button-container {
   bottom: 20px !important;
-    right: 28px !important;
-    position: fixed !important;
+  right: 28px !important;
+  position: fixed !important;
 }
 
 .footer-container,
@@ -4480,7 +4483,10 @@ code,
 }
 
 .global-loader.hidden {
-  display: none;
+  display: none !important;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .loader-spinner {

--- a/css/style.min.css
+++ b/css/style.min.css
@@ -3463,3 +3463,5 @@ main:focus {
   padding: 0 1.5rem;
 }
 
+.global-loader{position:fixed;top:0;left:0;height:100vh;width:100vw;background:rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;flex-direction:column;gap:10px;z-index:9999;backdrop-filter:blur(3px)}.global-loader.hidden{display:none!important;visibility:hidden;opacity:0;pointer-events:none}.loader-spinner{width:45px;height:45px;border:5px solid rgba(255,255,255,.4);border-top:5px solid #fff;border-radius:50%;animation:spin .8s linear infinite}.loader-text{color:#fff;font-size:16px;font-weight:600;letter-spacing:.5px}@keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
 
     <link rel="stylesheet" href="css/style.min.css" />
     <link rel="stylesheet" href="css/back-to-top.css" />
-    <link rel="stylesheet" href="css/animations.css" /> 
+    <link rel="stylesheet" href="css/animations.css" />
     <link rel="stylesheet" href="css/share-button.css" />
     <link rel="stylesheet" href="css/home-gsap.min.css" />
     <link rel="stylesheet" href="css/cursor-effect.css" />
     <link rel="stylesheet" href="css/scroll-buttons.css" />
     <link rel="stylesheet" href="css/stats-widget.css" />
     <link rel="stylesheet" href="css/keyboard-shortcuts.css" />
-    <link rel="stylesheet" href="css/focus.css">
+    <link rel="stylesheet" href="css/focus.css" />
 
     <link
       href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;800&display=swap"
@@ -168,18 +168,20 @@
         }
       }
     </style>
-    
   </head>
 
   <body class="hacker-theme">
-    <body class="hacker-theme">
-
-  <div id="global-loader" class="global-loader hidden" aria-live="polite" aria-label="Loading page">
-    <div class="loader-spinner"></div>
-     <p class="loader-text">Loading...</p>
+    <div
+      id="global-loader"
+      class="global-loader hidden"
+      aria-live="polite"
+      aria-label="Loading page"
+    >
+      <div class="loader-spinner"></div>
+      <p class="loader-text">Loading...</p>
     </div>
     <div id="scroll-progress-container">
-     <div id="scroll-progress-bar"></div>
+      <div id="scroll-progress-bar"></div>
     </div>
     <div id="scroll-progress-container">
       <div id="scroll-progress-bar"></div>
@@ -229,30 +231,32 @@
         </section>
 
         <section class="focus-areas" id="focus-areas" aria-labelledby="focus-heading">
-  <div class="container">
-    <div class="section-header-terminal">
-      <h2 id="focus-heading">
-        <i class="fas fa-crosshairs" aria-hidden="true"></i> FOCUS AREAS
-      </h2>
-      <div class="line-scanner" aria-hidden="true"></div>
-    </div>
+          <div class="container">
+            <div class="section-header-terminal">
+              <h2 id="focus-heading">
+                <i class="fas fa-crosshairs" aria-hidden="true"></i> FOCUS AREAS
+              </h2>
+              <div class="line-scanner" aria-hidden="true"></div>
+            </div>
 
-    <p class="section-sub">> Specialized tracks for skill development and project building</p>
+            <p class="section-sub">
+              > Specialized tracks for skill development and project building
+            </p>
 
-    <div class="focus-grid">
-      <div class="focus-card">
-        <div class="focus-icon"><i class="fas fa-code" aria-hidden="true"></i></div>
-        <h3>Web Development</h3>
-        <p>Full-stack development with modern frameworks and tools</p>
-        <a href="pages/projects.html" class="focus-link">View Projects</a>
-      </div>
+            <div class="focus-grid">
+              <div class="focus-card">
+                <div class="focus-icon"><i class="fas fa-code" aria-hidden="true"></i></div>
+                <h3>Web Development</h3>
+                <p>Full-stack development with modern frameworks and tools</p>
+                <a href="pages/projects.html" class="focus-link">View Projects</a>
+              </div>
 
-      <div class="focus-card">
-        <div class="focus-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
-        <h3>Embedded Systems</h3>
-        <p>IoT, microcontrollers, and hardware programming</p>
-        <a href="pages/projects.html" class="focus-link">View Projects</a>
-      </div>
+              <div class="focus-card">
+                <div class="focus-icon"><i class="fas fa-microchip" aria-hidden="true"></i></div>
+                <h3>Embedded Systems</h3>
+                <p>IoT, microcontrollers, and hardware programming</p>
+                <a href="pages/projects.html" class="focus-link">View Projects</a>
+              </div>
 
               <div class="focus-card">
                 <div class="focus-icon">
@@ -263,36 +267,41 @@
                 <a href="events.html" class="focus-link">Join Sessions →</a>
               </div>
 
-      <div class="focus-card">
-        <div class="focus-icon"><i class="fas fa-paint-brush" aria-hidden="true"></i></div>
-        <h3>Design</h3>
-        <p>UI/UX principles and creative visual solutions</p>
-        <a href="pages/projects.html" class="focus-link">View Portfolio</a>
-      </div>
+              <div class="focus-card">
+                <div class="focus-icon"><i class="fas fa-paint-brush" aria-hidden="true"></i></div>
+                <h3>Design</h3>
+                <p>UI/UX principles and creative visual solutions</p>
+                <a href="pages/projects.html" class="focus-link">View Portfolio</a>
+              </div>
 
-      <div class="focus-card">
-        <div class="focus-icon"><i class="fab fa-github" aria-hidden="true"></i></div>
-        <h3>Open Source</h3>
-        <p>Collaborative development and community contributions</p>
-        <a href="https://github.com/sayeeg-11/Pixel_Phantoms" target="_blank" class="focus-link">Contribute</a>
-      </div>
+              <div class="focus-card">
+                <div class="focus-icon"><i class="fab fa-github" aria-hidden="true"></i></div>
+                <h3>Open Source</h3>
+                <p>Collaborative development and community contributions</p>
+                <a
+                  href="https://github.com/sayeeg-11/Pixel_Phantoms"
+                  target="_blank"
+                  class="focus-link"
+                  >Contribute</a
+                >
+              </div>
 
-      <div class="focus-card">
-        <div class="focus-icon"><i class="fas fa-users" aria-hidden="true"></i></div>
-        <h3>Community Learning</h3>
-        <p>Peer-to-peer learning and knowledge sharing</p>
-        <a href="pages/join-us.html" class="focus-link">Join Community</a>
-      </div>
-    </div>
+              <div class="focus-card">
+                <div class="focus-icon"><i class="fas fa-users" aria-hidden="true"></i></div>
+                <h3>Community Learning</h3>
+                <p>Peer-to-peer learning and knowledge sharing</p>
+                <a href="pages/join-us.html" class="focus-link">Join Community</a>
+              </div>
+            </div>
 
-    <div class="focus-footer">
-      <p>
-        > Want to learn more about our complete mission?
-        <a href="about.html" class="cyber-link">Visit About Page</a>
-      </p>
-    </div>
-  </div>
-</section>
+            <div class="focus-footer">
+              <p>
+                > Want to learn more about our complete mission?
+                <a href="about.html" class="cyber-link">Visit About Page</a>
+              </p>
+            </div>
+          </div>
+        </section>
 
         <section class="hackathon-spotlight" aria-labelledby="hackathon-heading">
           <div class="section-header-terminal">
@@ -460,65 +469,64 @@
         </section>
 
         <!-- PROJECT ARCHIVE SECTION - SINGLE ROW -->
-<section class="project-mainframe" aria-labelledby="projects-heading">
-  <div class="container">
-    <h2 class="section-header-glitch" data-text="PROJECT_ARCHIVE" id="projects-heading">
-      <span aria-hidden="true">PROJECT_ARCHIVE</span>
-      <span class="sr-only">Project Archive</span>
-    </h2>
-    
-    <div class="project-matrix">
-      <article
-        class="proj-card"
-        data-href="pages/projects/cyberdeck.html"
-        data-category="web"
-        style="background-image: url('https://picsum.photos/seed/p1/400/300')"
-      >
-        <div class="proj-content">
-          <h3>CyberDeck_OS</h3>
-          <p>A custom Linux distro for hackers.</p>
-        </div>
-      </article>
-      
-      <article
-        class="proj-card"
-        data-href="pages/projects/neon-city.html"
-        data-category="design"
-        style="background-image: url('https://picsum.photos/seed/p2/400/300')"
-      >
-        <div class="proj-content">
-          <h3>Neon_City</h3>
-          <p>WebGL interactive experience.</p>
-        </div>
-      </article>
-      
-      <article
-        class="proj-card"
-        data-href="pages/projects/botnet.html"
-        data-category="web"
-        style="background-image: url('https://picsum.photos/seed/p3/400/300')"
-      >
-        <div class="proj-content">
-          <h3>Bot_Net_V2</h3>
-          <p>Discord automation bot.</p>
-        </div>
-      </article>
-      
-      <article
-        class="proj-card"
-        data-href="pages/projects/crypto-vault.html"
-        data-category="blockchain"
-        style="background-image: url('https://picsum.photos/seed/p4/400/300')"
-      >
-        <div class="proj-content">
-          <h3>Crypto_Vault</h3>
-          <p>Secure decentralized storage.</p>
-        </div>
-      </article>
-    </div>
-  </div>
-</section>
+        <section class="project-mainframe" aria-labelledby="projects-heading">
+          <div class="container">
+            <h2 class="section-header-glitch" data-text="PROJECT_ARCHIVE" id="projects-heading">
+              <span aria-hidden="true">PROJECT_ARCHIVE</span>
+              <span class="sr-only">Project Archive</span>
+            </h2>
 
+            <div class="project-matrix">
+              <article
+                class="proj-card"
+                data-href="pages/projects/cyberdeck.html"
+                data-category="web"
+                style="background-image: url('https://picsum.photos/seed/p1/400/300')"
+              >
+                <div class="proj-content">
+                  <h3>CyberDeck_OS</h3>
+                  <p>A custom Linux distro for hackers.</p>
+                </div>
+              </article>
+
+              <article
+                class="proj-card"
+                data-href="pages/projects/neon-city.html"
+                data-category="design"
+                style="background-image: url('https://picsum.photos/seed/p2/400/300')"
+              >
+                <div class="proj-content">
+                  <h3>Neon_City</h3>
+                  <p>WebGL interactive experience.</p>
+                </div>
+              </article>
+
+              <article
+                class="proj-card"
+                data-href="pages/projects/botnet.html"
+                data-category="web"
+                style="background-image: url('https://picsum.photos/seed/p3/400/300')"
+              >
+                <div class="proj-content">
+                  <h3>Bot_Net_V2</h3>
+                  <p>Discord automation bot.</p>
+                </div>
+              </article>
+
+              <article
+                class="proj-card"
+                data-href="pages/projects/crypto-vault.html"
+                data-category="blockchain"
+                style="background-image: url('https://picsum.photos/seed/p4/400/300')"
+              >
+                <div class="proj-content">
+                  <h3>Crypto_Vault</h3>
+                  <p>Secure decentralized storage.</p>
+                </div>
+              </article>
+            </div>
+          </div>
+        </section>
 
         <section class="terminal-updates" aria-label="Community Updates">
           <div class="terminal-window">
@@ -733,7 +741,6 @@
       // Render these immediately so the theme.js can find the toggle switch
       renderNavbar();
       renderFooter('');
-      
 
       document.addEventListener('DOMContentLoaded', function () {
         const skipLink = document.getElementById('skip-link');
@@ -909,16 +916,16 @@
     <script src="js/keyboard-shortcuts.js" defer></script>
 
     <script>
-      window.addEventListener('load', function() {
+      window.addEventListener('load', function () {
         const fixEvents = () => {
           // Fix links if JS overwrote them with 'events.html'
           const hackBtn = document.querySelector('.hackathon-spotlight .btn-hollow');
           if (hackBtn && hackBtn.getAttribute('href') === 'pages/events.html') {
-            hackBtn.href = "events.html";
+            hackBtn.href = 'events.html';
           }
           // Also check other event links
           document.querySelectorAll('a[href="pages/events.html"]').forEach(a => {
-            a.href = "events.html";
+            a.href = 'events.html';
           });
         };
         // Run immediately and after delay to catch async updates
@@ -937,6 +944,5 @@
       });
     </script>
     <script src="js/main.js"></script>
-
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -677,6 +678,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -737,6 +739,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -1428,6 +1431,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -1602,6 +1606,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },


### PR DESCRIPTION
## 📝 Description
Fixed the navbar left side where the logo/text was getting cut off and an extra "Lo" text was visible.  
Now the "Pixel Phantoms" logo and text are properly aligned and displayed without any extra or clipped text.

## 🔗 Related Issue
Fixes #670  
> **Note:** You must be assigned to an issue before submitting a PR.

## 🛠️ Type of Change
- [x] 🎨 **UI/UX Improvement** (CSS, Layout, Animations)
- [ ] ✨ **New Feature** (New page or functionality)
- [x] 🐞 **Bug Fix**
- [ ] 📝 **Documentation Update**
- [ ] 🚀 **Performance/Optimization**

## 🧪 Testing & Validation
- [x] I have checked the UI on **Mobile, Tablet, and Desktop** views.
- [x] I have verified the changes in both **Light and Dark modes**.
- [ ] (If applicable) I have verified that the `localStorage` logic (Event View Tracking) still works.

## 🚩 Checklist:
- [x] I have run `npm run format` to fix any styling issues.
- [x] I have run `npm run lint` and resolved all warnings/errors.
- [x] My code follows the project's folder structure (JS in `/js`, CSS in `/css`, Pages in `/pages`).
- [x] I have performed a self-review of my code.

## 📸 Screenshots / Demos
Before: Navbar logo/text was cut off and extra "Lo" was visible.  
After: Navbar logo and "Pixel Phantoms" text are fully visible and properly aligned.

(Attach screenshots here)
<img width="1862" height="490" alt="image" src="https://github.com/user-attachments/assets/0a602dd9-a72d-46b0-9a6c-6710555d155f" />
